### PR TITLE
Embed web assets

### DIFF
--- a/BaaSScheduler/BaaSScheduler.csproj
+++ b/BaaSScheduler/BaaSScheduler.csproj
@@ -14,4 +14,11 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
     <PackageReference Include="NCrontab" Version="3.3.3" />
   </ItemGroup>
+
+  <!-- Embed web assets so the service can run without external files -->
+  <ItemGroup>
+    <EmbeddedResource Include="wwwroot\**" />
+    <!-- Prevent static files from being copied to publish directory -->
+    <Content Remove="wwwroot\**" />
+  </ItemGroup>
 </Project>

--- a/BaaSScheduler/Program.cs
+++ b/BaaSScheduler/Program.cs
@@ -3,6 +3,8 @@ using BaaSScheduler;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Hosting.WindowsServices;
 using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.FileProviders;
+using System.Reflection;
 using Microsoft.AspNetCore.Mvc;
 
 // optional configuration file parameter
@@ -56,8 +58,12 @@ builder.WebHost.UseUrls($"http://{config.Web.Host}:{config.Web.Port}");
 
 var app = builder.Build();
 
+var embeddedProvider = new ManifestEmbeddedFileProvider(Assembly.GetExecutingAssembly(), "wwwroot");
+
 app.UseDefaultFiles();
+app.UseDefaultFiles(new DefaultFilesOptions { FileProvider = embeddedProvider });
 app.UseStaticFiles();
+app.UseStaticFiles(new StaticFileOptions { FileProvider = embeddedProvider });
 
 app.Use(async (context, next) =>
 {


### PR DESCRIPTION
## Summary
- embed `wwwroot` files so they're packaged into the executable
- serve embedded assets using `ManifestEmbeddedFileProvider`

## Testing
- `dotnet build BaaSScheduler/BaaSScheduler.csproj`
- `dotnet publish BaaSScheduler/BaaSScheduler.csproj -c Release -r win-x64 --self-contained true /p:PublishSingleFile=true`

------
https://chatgpt.com/codex/tasks/task_e_6840891664088320abb18473846cefd5