### PR TITLE
Embed wwwroot in executable

### DIFF
--- a/BaaSScheduler/BaaSScheduler.csproj
+++ b/BaaSScheduler/BaaSScheduler.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Generate a manifest of embedded resources so static files can be served -->
+    <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
     <UserSecretsId>dotnet-BaaSScheduler-c87029f8-4e42-4bd7-8f1f-d27adc11d8fa</UserSecretsId>
     <!-- Publishing properties are specified at publish time so the project can
          run cross-platform during development -->
@@ -13,5 +15,14 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
     <PackageReference Include="NCrontab" Version="3.3.3" />
+  </ItemGroup>
+
+  <!-- Embed web assets so the service can run without external files -->
+  <ItemGroup>
+    <!-- Preserve file paths in the manifest so the web host can find them -->
+    <!-- Embed static files without the wwwroot prefix so they serve from root -->
+    <EmbeddedResource Include="wwwroot\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
+    <!-- Prevent static files from being copied to publish directory -->
+    <Content Remove="wwwroot\**" />
   </ItemGroup>
 </Project>

--- a/BaaSScheduler/Program.cs
+++ b/BaaSScheduler/Program.cs
@@ -3,6 +3,8 @@ using BaaSScheduler;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Hosting.WindowsServices;
 using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.FileProviders;
+using System.Reflection;
 using Microsoft.AspNetCore.Mvc;
 
 // optional configuration file parameter
@@ -56,8 +58,12 @@ builder.WebHost.UseUrls($"http://{config.Web.Host}:{config.Web.Port}");
 
 var app = builder.Build();
 
+var embeddedProvider = new EmbeddedFileProvider(Assembly.GetExecutingAssembly(), "");
+
 app.UseDefaultFiles();
+app.UseDefaultFiles(new DefaultFilesOptions { FileProvider = embeddedProvider });
 app.UseStaticFiles();
+app.UseStaticFiles(new StaticFileOptions { FileProvider = embeddedProvider });
 
 app.Use(async (context, next) =>
 {


### PR DESCRIPTION
## Summary
- embed static files and expose them with `EmbeddedFileProvider`
- keep the wwwroot files out of the publish directory

## Testing
- `dotnet build BaaSScheduler/BaaSScheduler.csproj -c Release`
- `dotnet publish BaaSScheduler/BaaSScheduler.csproj -c Release -r win-x64 --self-contained true /p:PublishSingleFile=true`
- `dotnet BaaSScheduler/bin/Release/net8.0/BaaSScheduler.dll --console` *(served index.html successfully)*

------
https://chatgpt.com/codex/tasks/task_e_6840891664088320abb18473846cefd5